### PR TITLE
Fix for 2-level nested routes

### DIFF
--- a/src/app/[locale]/nested1/nested2/page.tsx
+++ b/src/app/[locale]/nested1/nested2/page.tsx
@@ -1,0 +1,21 @@
+import styles from "../../page.module.css";
+import { getIntl } from "@/lib/intl";
+
+type HomeProps = {
+  params: { locale: string };
+};
+
+export default async function Nested({ params: { locale } }: HomeProps) {
+  const intl = await getIntl(locale);
+  return (
+    <div className={styles.container}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>
+          {intl.formatMessage(
+            { id: "page.nested.title" }
+          )}
+        </h1>
+      </main>
+    </div>
+  );
+}

--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -3,5 +3,6 @@
   "page.home.head.title": "Next.js i18n example",
   "page.home.head.meta.description": "Next.js i18n example - English",
   "page.home.title": "Welcome to <b>Next.js i18n tutorial</b>",
-  "page.home.description": "You are currently viewing the homepage in English 🚀"
+  "page.home.description": "You are currently viewing the homepage in English 🚀",
+  "page.nested.title": "2-level nested route"
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -47,7 +47,7 @@ export function middleware(request: NextRequest) {
 
     const locale = isFirstVisit ? getLocale(request, i18n) : defaultLocale;
 
-    let newPath = `${locale}${pathname}`;
+    let newPath = `/${locale}${pathname}`;
     if (request.nextUrl.search) newPath += request.nextUrl.search;
 
     response =


### PR DESCRIPTION
1. Consider a nested route `app/[locale]/nested1/nested2/page.tsx`
2. Open `localhost:3000/fr/nested1/nested2`, verify that the page loads
3. Open `localhost:3000/nested1/nested2`

**Expected**: English version is loaded
**Observed**: 404

The change in this PR fixes it.